### PR TITLE
Add option to skip the attempt to create the bucket

### DIFF
--- a/cmd/logshare-cli/main.go
+++ b/cmd/logshare-cli/main.go
@@ -38,7 +38,7 @@ func main() {
 	}
 }
 
-func setupGoogleStr(projectID string, bucketName string, filename string) (*gcs.Writer, error) {
+func setupGoogleStr(projectID string, bucketName string, filename string, skipCreateBucket bool) (*gcs.Writer, error) {
 	gCtx := context.Background()
 
 	gClient, error := gcs.NewClient(gCtx)
@@ -48,11 +48,13 @@ func setupGoogleStr(projectID string, bucketName string, filename string) (*gcs.
 
 	gBucket := gClient.Bucket(bucketName)
 
-	if error = gBucket.Create(gCtx, projectID, nil); strings.Contains(error.Error(), "409") {
-		log.Printf("Bucket %v already exists.\n", bucketName)
-		error = nil
-	} else if error != nil {
-		return nil, error
+	if !skipCreateBucket {
+		if error = gBucket.Create(gCtx, projectID, nil); strings.Contains(error.Error(), "409") {
+			log.Printf("Bucket %v already exists.\n", bucketName)
+			error = nil
+		} else if error != nil {
+			return nil, error
+		}
 	}
 
 	obj := gBucket.Object(filename)
@@ -82,7 +84,7 @@ func run(conf *config) func(c *cli.Context) error {
 		if conf.googleStorageBucket != "" {
 			fileName := "cloudflare_els_" + conf.zoneID + "_" + strconv.Itoa(int(time.Now().Unix())) + ".json"
 
-			gcsWriter, err := setupGoogleStr(conf.googleProjectID, conf.googleStorageBucket, fileName)
+			gcsWriter, err := setupGoogleStr(conf.googleProjectID, conf.googleStorageBucket, fileName, conf.skipCreateBucket)
 			if err != nil {
 				return err
 			}
@@ -143,6 +145,7 @@ func parseFlags(conf *config, c *cli.Context) error {
 	conf.listFields = c.Bool("list-fields")
 	conf.googleStorageBucket = c.String("google-storage-bucket")
 	conf.googleProjectID = c.String("google-project-id")
+	conf.skipCreateBucket = c.Bool("skip-create-bucket")
 
 	return conf.Validate()
 }
@@ -161,6 +164,7 @@ type config struct {
 	listFields          bool
 	googleStorageBucket string
 	googleProjectID     string
+	skipCreateBucket    bool
 }
 
 func (conf *config) Validate() error {
@@ -245,5 +249,9 @@ var flags = []cli.Flag{
 	cli.StringFlag{
 		Name:  "google-project-id",
 		Usage: "Project ID of the Google Cloud Storage Bucket to upload logs to",
+	},
+	cli.BoolFlag{
+		Name:  "skip-create-bucket",
+		Usage: "Do not attempt to create the bucket specified by --google-storage-bucket",
 	},
 }


### PR DESCRIPTION
In my case, the bucket that I want to write to is tightly locked down and the only permissions that are given are those that are absolutely needed.  In this case, the account does not have Editor permissions on the bucket, so the Bucket Create call will always fail with an authorization error.

This PR adds the ability to skip bucket creation via a new CLI option.  This is useful in situations where the user that is trying to write to the bucket has no permissions other than roles/storage.objectCreator