### PR TITLE
[NOJIRA] -- switch to wpe repo for go package

### DIFF
--- a/cmd/logshare-cli/main.go
+++ b/cmd/logshare-cli/main.go
@@ -10,9 +10,9 @@ import (
 
 	gcs "cloud.google.com/go/storage"
 	cloudflare "github.com/cloudflare/cloudflare-go"
-	"github.com/cloudflare/logshare"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
+	"github.com/wpengine/logshare"
 	"golang.org/x/net/context"
 )
 


### PR DESCRIPTION
Switch to pulling the package from wpengine rather than cloudflare to get the bucket fix.